### PR TITLE
Correction for in-pod directory naming

### DIFF
--- a/fio_statefulset.yaml
+++ b/fio_statefulset.yaml
@@ -18,7 +18,12 @@ spec:
       - name: fio
         image: joshuarobinson/fio:3.19
         command: ["fio"]
-        args: ["/configs/fio.job", "--eta=never", "--filename_format=$(hostname)/$jobnum.$filenum", "--directory=/scratch/"]
+        args: ["/configs/fio.job", "--eta=never", "--filename_format=$(HOSTNAME)/$jobnum.$filenum", "--directory=/scratch/"]
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         volumeMounts:
         - name: fio-config-vol
           mountPath: /configs


### PR DESCRIPTION
Shell expansion not working as expected, so fio directory in /scratch was being named literal '$(hostname)'. Proposed change leverages the downward API to set variable instead. Used caps HOSTNAME so as not to interfere with anything else potentially using lowercase hostname.